### PR TITLE
Add library seedrandom.js

### DIFF
--- a/data.js
+++ b/data.js
@@ -2549,6 +2549,13 @@ module.exports = [
     source: "https://raw.githubusercontent.com/chrisbateman/impetus/master/impetus.js"
   },
   {
+    name: "seedrandom.js",
+    tags: ["random", "RNG", "PRNG"],
+    description: "A seeded random number generator. Can override Math.random or return a generator function.",
+    url: "https://github.com/davidbau/seedrandom",
+    source: "https://raw.githubusercontent.com/davidbau/seedrandom/master/seedrandom.js"
+  },
+  {
     name: "Humane JS",
     tags: ["notification", "alert"],
     description: "A simple, modern, browser notification system",


### PR DESCRIPTION
Adds [seedrandom.js](https://github.com/davidbau/seedrandom), a seeded random number generator. It is 0.9 kB minified and gzipped.

After this addition, `make` doesn’t report any errors related to the seedrandom.js entry.