### PR TITLE
Added pygy/j2c

### DIFF
--- a/data.js
+++ b/data.js
@@ -438,6 +438,14 @@ module.exports = [
     source: "https://raw.githubusercontent.com/jesseskinner/hoverboard/master/dist/hoverboard.js"
   },
   {
+    name: "j2c",
+    github: "pygy/j2c",
+    tags: ["CSS", "compiler", "preprocessor", "SASS", "LESS", "Stylus", "JSON"],
+    description: "CSS preprocessor working from JavaScript objects.",
+    url: "http://j2c.py.gy",
+    source: "https://raw.githubusercontent.com/pygy/j2c/master/dist/j2c.global.js"
+  },
+  {
     name: "JsChannels",
     github: "brophdawg11/JsChannels",
     tags: ["Channels", "core.async", "async", "Promise", "Deferred", "Deferreds", "Promises"],


### PR DESCRIPTION
This is a CSS preprocessor working from JS objects. Raw source is 6KB, mingzipped down to 800 bytes.

http://j2c.py.gy https://github.com/pygy/j2c