### PR TITLE
add populate.js

### DIFF
--- a/data.js
+++ b/data.js
@@ -4687,5 +4687,15 @@ module.exports = [
     description: "Ultra-simple promise based wrapper around XMLHttpRequest",
     url: "https://github.com/radiosilence/xr",
     source: "https://raw.githubusercontent.com/radiosilence/xr/master/xr.js"
+  },
+  {
+  	 {
+    name: "populate.js",
+    github: "dannyvankooten/populate.js",
+    tags: ["json", "form"],
+    description: "Populate form fields from a JSON object. Extremely small, no dependencies.",
+    url: "https://github.com/dannyvankooten/populate.js",
+    source: "https://raw.githubusercontent.com/dannyvankooten/populate.js/master/populate.js"
+  }
   }
 ];


### PR DESCRIPTION
Adds [populate.js](https://github.com/dannyvankooten/populate.js) to the site, a micro-function which allows you to populate form fields from a JSON object. 