### PR TITLE
Add uniloc

### DIFF
--- a/data.js
+++ b/data.js
@@ -8,6 +8,13 @@
 // See examples below.
 
 module.exports = [
+  {
+    name: "uniloc",
+    github: "unicorn-standard/uniloc",
+    tags: ["router", "routing", "query", "parser", "parsing", "parameters", "uri"],
+    url: "http://unicornstandard.com/packages/uniloc.html",
+    source: "https://raw.githubusercontent.com/unicorn-standard/uniloc/master/uniloc.js"
+  },
      {
     name: "MagJS",
     github: "magnumjs/mag.js",


### PR DESCRIPTION
uniloc solves two problems:

- parsing URIs into named routes/query parameters
- generating URIs from a route name and it's query parameters

It works on node, and in the browser.